### PR TITLE
Add placeholder message for empty content pages

### DIFF
--- a/src/pages/content.md
+++ b/src/pages/content.md
@@ -6,4 +6,4 @@ hide_table_of_contents: true
 
 # Content
 
-Insert content here
+Coming soon!

--- a/src/pages/css.md
+++ b/src/pages/css.md
@@ -6,4 +6,4 @@ hide_table_of_contents: true
 
 # CSS
 
-Insert content here
+Coming soon!

--- a/src/pages/deployment.md
+++ b/src/pages/deployment.md
@@ -6,4 +6,4 @@ hide_table_of_contents: true
 
 # Deployment
 
-Insert content here
+Coming soon!

--- a/src/pages/design.md
+++ b/src/pages/design.md
@@ -6,4 +6,4 @@ hide_table_of_contents: true
 
 # Design
 
-Insert content here
+Coming soon!

--- a/src/pages/html.md
+++ b/src/pages/html.md
@@ -6,4 +6,4 @@ hide_table_of_contents: true
 
 # HTML
 
-Insert content here
+Coming soon!

--- a/src/pages/javascript.md
+++ b/src/pages/javascript.md
@@ -6,4 +6,4 @@ hide_table_of_contents: true
 
 # JavaScript
 
-Insert content here
+Coming soon!

--- a/src/pages/markdown-page.md
+++ b/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.


### PR DESCRIPTION
# Description

While content pages are still being worked on, I added a placeholder that says "Coming soon". It looks a bit nicer than "Insert content here" so we can launch the site without these.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
